### PR TITLE
Add table name with the deleted_at filter

### DIFF
--- a/src/SoftDeletes/index.ts
+++ b/src/SoftDeletes/index.ts
@@ -35,7 +35,7 @@ export function SoftDeletes<T extends NormalizeConstructor<LucidModel>> (supercl
         if (!this.$ignoreDeleted) {
           return
         }
-        query.whereNull('deleted_at')
+        query.whereNull(`${query.model.table}.deleted_at`)
       }
       this.before('find', ignoreDeleted)
       this.before('fetch', ignoreDeleted)

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -57,6 +57,26 @@ export async function setup (destroyDb: boolean = true) {
     })
   }
 
+  const hasBooks = await db.schema.hasTable('books')
+  if (!hasBooks) {
+    await db.schema.createTable('books', (table) => {
+      table.increments().primary()
+      table.string('name').unique()
+      table.timestamps()
+      table.timestamp('deleted_at', { useTz: true })
+    })
+  }
+
+  const hasTicket = await db.schema.hasTable('authors')
+  if (!hasTicket) {
+    await db.schema.createTable('authors', (table) => {
+      table.increments().primary()
+      table.string('name')
+      table.timestamps()
+      table.timestamp('deleted_at', { useTz: true })
+    })
+  }
+
   const hasRoles = await db.schema.hasTable('roles')
   if (!hasRoles) {
     await db.schema.createTable('roles', (table) => {
@@ -75,6 +95,18 @@ export async function setup (destroyDb: boolean = true) {
     })
   }
 
+  const hasBooksAuhors = await db.schema.hasTable('author_book')
+  if (!hasBooksAuhors) {
+    await db.schema.createTable('author_book', (table) => {
+      table.increments().primary()
+      table.integer('book_id')
+      table.integer('author_id')
+      table.foreign('book_id').references('books.id')
+      table.foreign('author_id').references('authors.id')
+      table.timestamp('deleted_at', { useTz: true })
+    })
+  }
+
   if (destroyDb) {
     await db.destroy()
   }
@@ -85,8 +117,11 @@ export async function cleanup () {
 
   await db.schema.dropTableIfExists('users')
   await db.schema.dropTableIfExists('industries')
+  await db.schema.dropTableIfExists('books')
+  await db.schema.dropTableIfExists('authors')
   await db.schema.dropTableIfExists('roles')
   await db.schema.dropTableIfExists('industry_user')
+  await db.schema.dropTableIfExists('author_book')
 
   await db.destroy()
   await fs.cleanup()


### PR DESCRIPTION
When using the model to list several elements with preload, lucid creates an inner join and the deleted_at column is left without the identifier of which table it is, causing the error:
I 45
> Error: select authors.*, author_book.book_id as pivot_book_id, author_book.author_id as pivot_author_id from authors inner join author_book on authors.id = author_book.author_id where author_book.book_id in (1) and deleted_at is null - SQLITE_ERROR: ambiguous column name: deleted_at
